### PR TITLE
New Design: drop prev and use parent link

### DIFF
--- a/include/json/common.h
+++ b/include/json/common.h
@@ -43,7 +43,7 @@ typedef enum json_type_t {
 } json_type_t;
 
 typedef struct json_t {
-  struct json_t *prev;
+  struct json_t *parent;
   struct json_t *next;
   const char    *key;
   void          *value;

--- a/include/json/print.h
+++ b/include/json/print.h
@@ -93,7 +93,7 @@ json_print_ex(const FILE   * __restrict ostream,
 
     if (json->next) {
       json = json->next;
-    } else if (parent) {
+    } else if ((parent = json->parent)) {
       do {
         --pad;
 
@@ -114,7 +114,7 @@ json_print_ex(const FILE   * __restrict ostream,
           printf("\n");
 
         json   = parent->next;
-        parent = json_parent(parent);
+        parent = parent->parent;
       } while (!json && parent);
     } else {
       break;

--- a/include/json/util.h
+++ b/include/json/util.h
@@ -200,6 +200,7 @@ json_key_eq(const json_t * __restrict obj, const char * __restrict str) {
 JSON_INLINE
 const json_t*
 json_parent(const json_t * __restrict obj) {
+  /*
   const json_t *prev;
   if (!obj)
     return NULL;
@@ -209,7 +210,9 @@ json_parent(const json_t * __restrict obj) {
     obj  = obj->prev;
   } while (obj && obj->value != prev);
 
-  return obj;
+  return obj;*/
+
+  return obj->parent;
 }
 
 #endif /* json_util_h */


### PR DESCRIPTION
The **json** library supports both reverse order and normal order. Unlike reverse order, it is not easy (or fast) to implement the normal order for now by using **prev** links.

Now I would like to introduce new design which drops **prev** links and brings **parent** links.

- Every item has **parent** and **next**: so you can switch to parent easily, but three is no easy way to get back item (I don't think we need this, do we?).

if we need **prev** in the future we may update the design

Now it is fast to parse JSON as normal and reverse order 🤗